### PR TITLE
ExtendedAddress

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,9 +1,9 @@
 package ihex
 
 func Checksum(buf []byte) (sum byte) {
-    for _, x := range buf {
-        sum += x
-    }
-    
-    return -sum
+	for _, x := range buf {
+		sum += x
+	}
+
+	return -sum
 }

--- a/decoder.go
+++ b/decoder.go
@@ -1,27 +1,49 @@
 package ihex
 
 import (
-    "bufio"
-    "fmt"
-    "io"
-    "strings"
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
 )
 
 // Parses IHEX files.
 type Decoder struct {
-    scanner *bufio.Scanner
-    rec Record
-    err error
-    lineno int
+	scanner       *bufio.Scanner
+	rec           Record
+	err           error
+	lineno        int
+	addressOffset ExtAddress
 }
 
 // Create a new Decoder using input from the given io.Reader.
 func NewDecoder(r io.Reader) (d *Decoder) {
-    scanner := bufio.NewScanner(r)
-    return &Decoder{
-        scanner: scanner,
-        lineno: 0,
-    }
+	scanner := bufio.NewScanner(r)
+	return &Decoder{
+		scanner:       scanner,
+		lineno:        0,
+		addressOffset: 0,
+	}
+}
+
+func (d *Decoder) extendAddress(rec *Record) error {
+	//Bytes to int 16
+	switch rec.Type {
+	case ExtendedSegmentAddress: //20-bit addressing
+		addressModifier := ExtAddress(rec.Data[0])<<8 + ExtAddress(rec.Data[1])
+		//Lower 4 bits of an extended segment address should be 0
+		//according to the spec
+		if addressModifier&0xF > 0 {
+			return fmt.Errorf("Extended segment address non-integer multiple of 16: %v", d.addressOffset)
+		}
+		d.addressOffset = addressModifier << 4
+	case ExtendedLinearAddress: //32-bit addressing
+		addressModifier := ExtAddress(rec.Data[0])<<8 + ExtAddress(rec.Data[1])
+		d.addressOffset = addressModifier << 16
+	case Data:
+		rec.ExtendedAddress = d.addressOffset + ExtAddress(rec.Address)
+	}
+	return nil
 }
 
 // Read and decode one record from the source, returning true if the record was
@@ -31,45 +53,66 @@ func NewDecoder(r io.Reader) (d *Decoder) {
 // if an error occurred. The scanned record can be retrieved with the Record
 // method.
 func (d *Decoder) Scan() (ok bool) {
-    if d.err != nil || !d.scanner.Scan() {
-        return false
-    }
-    
-    d.lineno++
-    
-    line := strings.Trim(d.scanner.Text(), " \t\r\n")
-    if len(line) == 0 {
-        // try again
-        return d.Scan()
-    }
-    
-    if line[0] != ':' {
-        d.err = fmt.Errorf("parse error at line %d: line does not begin with a colon", d.lineno)
-        return false
-    }
-    
-    rec, err := DecodeRecordHex(line)
-    if err != nil {
-        d.err = fmt.Errorf("parse error at line %d: %s", d.lineno, err.Error())
-        return false
-    } else {
-        d.rec = rec
-        return true
-    }
-    
+	if d.err != nil || !d.scanner.Scan() {
+		return false
+	}
+
+	d.lineno++
+
+	line := strings.Trim(d.scanner.Text(), " \t\r\n")
+	if len(line) == 0 {
+		// try again
+		return d.Scan()
+	}
+
+	if line[0] != ':' {
+		d.err = fmt.Errorf("parse error at line %d: line does not begin with a colon", d.lineno)
+		return false
+	}
+
+	rec, err := DecodeRecordHex(line)
+	if err != nil {
+		d.err = fmt.Errorf("parse error at line %d: %s", d.lineno, err.Error())
+		return false
+	}
+
+	err = d.extendAddress(&rec)
+	if err != nil {
+		d.err = err
+		return false
+	}
+
+	d.rec = rec
+	return true
+}
+
+// ScanData returns the next Data record. Any extended segment or
+// linear addresses are processed but not returned -- the function
+// calls itself recursively until the next data record or EOF is
+// encountered
+func (d *Decoder) ScanData() (ok bool) {
+	if !d.Scan() {
+		return false
+	}
+
+	if d.rec.Type != Data {
+		return d.ScanData()
+	}
+
+	return true
 }
 
 // Returns the most recently parsed record. An empty record is returned if Scan
 // has not yet been called, or if Scan has never returned true.
 func (d *Decoder) Record() (rec Record) {
-    return d.rec
+	return d.rec
 }
 
 // Returns the first error that occurred during parsing, or nil if there was no
 // error.
 func (d *Decoder) Err() (err error) {
-    if d.err == nil {
-        return d.scanner.Err()
-    }
-    return d.err
+	if d.err == nil {
+		return d.scanner.Err()
+	}
+	return d.err
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,19 +1,19 @@
 package ihex
 
 import (
-    "os"
+	"os"
 )
 
 func ExampleDecoder() {
-    d := NewDecoder(os.Stdin)
-    
-    for d.Scan() {
-        // do something with d.Record()
-    }
-    
-    // check if there was an error during parsing
-    err := d.Err()
-    if err != nil {
-        // handle the error
-    }
+	d := NewDecoder(os.Stdin)
+
+	for d.Scan() {
+		// do something with d.Record()
+	}
+
+	// check if there was an error during parsing
+	err := d.Err()
+	if err != nil {
+		// handle the error
+	}
 }

--- a/record.go
+++ b/record.go
@@ -1,50 +1,72 @@
 package ihex
 
 import (
-    "encoding/hex"
-    "fmt"
-    "strings"
+	"encoding/hex"
+	"fmt"
+	"strings"
 )
 
+//RecordType is a value from 0 to 5 as described in
+//the intel hex spec (http://www.piclist.com/techref/fileext/hex/intel.htm)
 type RecordType uint8
 
 const (
-    Data RecordType = 0x00
-    EndOfFile RecordType = 0x01
+	Data                   RecordType = 0x00
+	EndOfFile                         = 0x01
+	ExtendedSegmentAddress            = 0x02
+	StartSegmentAddress               = 0x03
+	ExtendedLinearAddress             = 0x04
+	StartLinearAddress                = 0x05
 )
+
+//ExtAddress represents an extended address of width up to 32-bits
+type ExtAddress uint32
+
+//ExtAddressSlice is defined in order to allow implemention of the Sort
+//interface for client convenience. Invoke as follows:
+//  import "sort"
+//	addressesToSort := []ExtAddress{....}
+//	sort.Sort(ExtAddressSlice(addressesToSort))
+type ExtAddressSlice []ExtAddress
+func (a ExtAddressSlice) Len() int           { return len(a) }
+func (a ExtAddressSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ExtAddressSlice) Less(i, j int) bool { return a[i] < a[j] }
 
 // Represents a single IHEX record.
 type Record struct {
-    // The type of record (either Data or EndOfFile).
-    Type RecordType
-    
-    // The address assocated with the record's data (for Data records).
-    Address uint16
-    
-    // The payload of the record.
-    Data []byte
+	// The type of record
+	Type RecordType
+
+	// The address associated with the record's data (for Data records).
+	Address uint16
+
+	// The Extended address associated with the record's data
+	ExtendedAddress ExtAddress
+
+	// The payload of the record.
+	Data []byte
 }
 
 // Interpreting bytes as the binary form of an IHEX record, decode and return a
 // Record. err may be non-nil if there was a checksum mismatch.
 func DecodeRecord(bytes []byte) (rec Record, err error) {
-    dataLen := int(bytes[0])
-    address := (uint16(bytes[1]) << 8) | uint16(bytes[2])
-    recType := RecordType(bytes[3])
-    
-    checksumIndex := 4 + dataLen
-    if bytes[checksumIndex] != Checksum(bytes[:checksumIndex]) {
-        return rec, fmt.Errorf("checksum mismatch")
-    }
-    
-    data := make([]byte, dataLen)
-    copy(data, bytes[4:checksumIndex])
-    
-    return Record{
-        Type: recType,
-        Address: address,
-        Data: data,
-    }, nil
+	dataLen := int(bytes[0])
+	address := (uint16(bytes[1]) << 8) | uint16(bytes[2])
+	recType := RecordType(bytes[3])
+
+	checksumIndex := 4 + dataLen
+	if bytes[checksumIndex] != Checksum(bytes[:checksumIndex]) {
+		return rec, fmt.Errorf("checksum mismatch")
+	}
+
+	data := make([]byte, dataLen)
+	copy(data, bytes[4:checksumIndex])
+
+	return Record{
+		Type:    recType,
+		Address: address,
+		Data:    data,
+	}, nil
 }
 
 // Interpreting hexStr as the hexadecimal form of an IHEX record with or without
@@ -52,29 +74,33 @@ func DecodeRecord(bytes []byte) (rec Record, err error) {
 // non-nil if there was a checksum mismatch or if the decoding from hexadecimal
 // failed.
 func DecodeRecordHex(hexStr string) (rec Record, err error) {
-    bytes, err := hex.DecodeString(strings.TrimLeft(hexStr, ":"))
-    if err != nil {
-        return rec, err
-    }
-    return DecodeRecord(bytes)
+	bytes, err := hex.DecodeString(strings.TrimLeft(hexStr, ":"))
+	if err != nil {
+		return rec, err
+	}
+	return DecodeRecord(bytes)
 }
 
 // Encode the record to the binary form of an IHEX record.
 func (rec Record) Encode() (bytes []byte) {
-    bytes = make([]byte, len(rec.Data) + 5)
-    bytes[0] = byte(len(rec.Data))
-    bytes[1] = byte(rec.Address >> 8)
-    bytes[2] = byte(rec.Address)
-    bytes[3] = byte(rec.Type)
-    copy(bytes[4:], rec.Data)
-    
-    checksumIndex := 4 + len(rec.Data)
-    bytes[checksumIndex] = Checksum(bytes[:checksumIndex])
-    return bytes
+	bytes = make([]byte, len(rec.Data)+5)
+	bytes[0] = byte(len(rec.Data))
+	bytes[1] = byte(rec.Address >> 8)
+	bytes[2] = byte(rec.Address)
+	bytes[3] = byte(rec.Type)
+	copy(bytes[4:], rec.Data)
+
+	checksumIndex := 4 + len(rec.Data)
+	bytes[checksumIndex] = Checksum(bytes[:checksumIndex])
+	return bytes
 }
 
 // Encode the record to the hexadecimal form of an IHEX record, with the leading
 // start token (colon).
 func (rec Record) EncodeHex() (hexStr string) {
-    return hex.EncodeToString(rec.Encode())
+	return hex.EncodeToString(rec.Encode())
+}
+
+func (rec *Record) String() string {
+	return fmt.Sprintf("ExtendedAddress: %x / Address: %x / Data %x", rec.ExtendedAddress, rec.Address, rec.Data)
 }

--- a/record_test.go
+++ b/record_test.go
@@ -1,37 +1,37 @@
 package ihex
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestDecodeRecord(t *testing.T) {
-    input := ":1004F0003E010894611C711CD501C4010197A1093A"
-    rec, err := DecodeRecordHex(input)
-    if err != nil {
-        t.Error("DecodeRecordHex returned an error: %s", err.Error())
-    }
-    
-    if rec.Type != 0x00 {
-        t.Error("rec.Type: expected 0x00, got 0x%02X", rec.Type)
-    }
-    
-    if rec.Address != 0x04F0 {
-        t.Error("rec.Address: expected 0x04F0, got 0x%02X", rec.Address)
-    }
-    
-    if len(rec.Data) != 16 {
-        t.Error("rec.Data: expected length 16, got length %d", len(rec.Data))
-    }
-    
-    if rec.Data[0] != 0x3E {
-        t.Error("rec.Data[0]: expected 0x3E, got 0x%02X", rec.Data[0])
-    }
-    
-    if rec.Data[1] != 0x01 {
-        t.Error("rec.Data[1]: expected 0x01, got 0x%02X", rec.Data[1])
-    }
-    
-    if rec.Data[15] != 0x09 {
-        t.Error("rec.Data[15]: expected 0x09, got 0x%02X", rec.Data[15])
-    }
+	input := ":1004F0003E010894611C711CD501C4010197A1093A"
+	rec, err := DecodeRecordHex(input)
+	if err != nil {
+		t.Error("DecodeRecordHex returned an error: %s", err.Error())
+	}
+
+	if rec.Type != 0x00 {
+		t.Error("rec.Type: expected 0x00, got 0x%02X", rec.Type)
+	}
+
+	if rec.Address != 0x04F0 {
+		t.Error("rec.Address: expected 0x04F0, got 0x%02X", rec.Address)
+	}
+
+	if len(rec.Data) != 16 {
+		t.Error("rec.Data: expected length 16, got length %d", len(rec.Data))
+	}
+
+	if rec.Data[0] != 0x3E {
+		t.Error("rec.Data[0]: expected 0x3E, got 0x%02X", rec.Data[0])
+	}
+
+	if rec.Data[1] != 0x01 {
+		t.Error("rec.Data[1]: expected 0x01, got 0x%02X", rec.Data[1])
+	}
+
+	if rec.Data[15] != 0x09 {
+		t.Error("rec.Data[15]: expected 0x09, got 0x%02X", rec.Data[15])
+	}
 }


### PR DESCRIPTION
Hi Kieran,

Thanks for the ihex-go library -- nice clean approach to parsing hex files. I've extended your code to handle extended address records (both linear and segment types), which simplifies my life a bit when working with hex files generated using Microchip tools. Done it in such a way as to leave your existing API unchanged (I hope). Added a new ExtendedAddress member to Record and a new ScanData method to decoder.go. ScanData just wraps the existing Scan method, calling itself recursively when an ExtendedAddress record is encountered to eliminate the need to check record type in client code.

Also defined types to implement the sort.Sort interface on a set of ExtendedAddresses, which may not be all that useful. Seemed like a good idea at the time though :)

Passed it through go fmt early on, so more changes showing up in diff than ideal. Do you have some alternate settings you use? If so I can apply at my end. Of course, you may have no interest in this changeset at all :)

P.S. I've only verified correct handling of the ExtendedLinear record type, as that's all the Microchip hex files use.
